### PR TITLE
Accesssibility fix on displaying channel button

### DIFF
--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeListItem/index.vue
@@ -52,6 +52,8 @@
                             getTitleClass(node),
                           ]"
                           dir="auto"
+                          tabindex="0"
+                          :aria-label="getTitle(node)"
                         >
                           {{ getTitle(node) }}
                         </h3>

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeValidator.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ContentNodeValidator.vue
@@ -1,7 +1,7 @@
 <template>
 
   <span v-if="noTitle && !hideTitleValidation" class="red--text title">
-    <Icon color="red">error</Icon>
+    <Icon tabindex="0" color="red" aria-label="Missing title">error</Icon>
     <span class="mx-1">
       {{ $tr('missingTitle') }}
     </span>
@@ -9,7 +9,7 @@
   <span v-else-if="error" class="mx-2">
     <VTooltip bottom>
       <template #activator="{ on }">
-        <Icon color="red" v-on="on">
+        <Icon tabindex="0" color="red" v-on="on" aria-label="Error Missing Field Either Question or MetaData">
           error
         </Icon>
       </template>
@@ -52,6 +52,7 @@
       },
       error() {
         if (!this.node.complete) {
+          console.log(this.node.complete)
           return this.$tr('incompleteText');
         } else if (this.node.total_count && this.node.error_count >= this.node.total_count) {
           return this.$tr('allIncompleteDescendantsText', { count: this.node.error_count });

--- a/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
+++ b/contentcuration/contentcuration/frontend/channelEdit/components/ResourcePanel.vue
@@ -43,13 +43,13 @@
       <Tabs v-if="isExercise" slider-color="primary">
         <VTab class="px-2" :to="{ query: { tab: 'questions' } }" exact>
           {{ $tr('questions') }}
-          <Icon v-if="invalidQuestions" color="red" small class="mx-2">
+          <Icon v-if="invalidQuestions" tabindex="0" color="red" aria-label = "Incomplete Question" small class="mx-2">
             error
           </Icon>
         </VTab>
         <VTab class="px-2" :to="{ query: { tab: 'details' } }" exact>
           {{ $tr('details') }}
-          <Icon v-if="invalidDetails" color="red" small class="mx-2">
+          <Icon v-if="invalidDetails" tabindex="0" color="red" aria-label="Incomplete Details" small class="mx-2">
             error
           </Icon>
         </VTab>
@@ -106,7 +106,7 @@
             <VLayout align-center justify-center fill-height>
               <VTooltip bottom>
                 <template #activator="{ on }">
-                  <Icon color="red" v-on="on">
+                  <Icon color="red" v-on="on" tabindex="0" :aria-label="$tr('noFilesError')">
                     error
                   </Icon>
                 </template>
@@ -121,7 +121,7 @@
             :label="$tr('questions')"
           >
             <span v-if="!assessmentItems.length" class="red--text">
-              <Icon color="red" small>error</Icon>
+              <Icon color="red" small tabindex="0" :aria-label="$tr('noQuestionsError')">error</Icon>
               <span class="mx-1">{{ $tr('noQuestionsError') }}</span>
             </span>
             <span v-else>
@@ -133,7 +133,7 @@
             :label="$tr('masteryCriteria')"
           >
             <span v-if="noMasteryModel" class="red--text">
-              <Icon color="red" small>error</Icon>
+              <Icon color="red" small tabindex="0" :aria-label="$tr('noMasteryModelError')">error</Icon>
               <span class="mx-1">{{ $tr('noMasteryModelError') }}</span>
             </span>
             <span v-else>
@@ -250,14 +250,14 @@
             <DetailsRow :label="$tr('aggregator')" :text="getText('aggregator')" notranslate />
             <DetailsRow :label="$tr('license')">
               <span v-if="noLicense" class="red--text">
-                <Icon color="red" small>error</Icon>
+                <Icon color="red"  small tabindex="0" :aria-label="$tr('noLicenseError')">error</Icon>
                 <span class="mx-1">{{ $tr('noLicenseError') }}</span>
               </span>
               <p v-else>
                 {{ licenseName }}
               </p>
-              <p v-if="noLicenseDescription" class="red--text">
-                <Icon color="red" small>
+              <p v-if="noLicenseDescription" class="red--text" tabindex="0" :aria-label="$tr('noLicenseDescriptionError')">
+                <Icon color="red" small :aria-label="$tr('noLicenseDescriptionError')">
                   error
                 </Icon>
                 <span class="mx-1">{{ $tr('noLicenseDescriptionError') }}</span>
@@ -268,7 +268,7 @@
             </DetailsRow>
             <DetailsRow :label="$tr('copyrightHolder')">
               <span v-if="noCopyrightHolder" class="red--text">
-                <Icon color="red" small>error</Icon>
+                <Icon color="red" small tabindex="0" :aria-label="$tr('noLicenseDescriptionError')">error</Icon>
                 <span class="mx-1">{{ $tr('noCopyrightHolderError') }}</span>
               </span>
               <span v-else class="notranslate">
@@ -283,7 +283,7 @@
               </div>
               <DetailsRow :label="$tr('availableFormats')">
                 <span v-if="!primaryFiles.length" class="red--text">
-                  <Icon color="red" small>error</Icon>
+                  <Icon color="red" small tabindex="0" :aria-label="$tr('noFilesError')">error</Icon>
                   <span class="mx-1">{{ $tr('noFilesError') }}</span>
                 </span>
                 <ExpandableList


### PR DESCRIPTION
<!-- Please remove any unused sections.

Note that anything written between these symbols will not appear in the actual, published PR. They serve as instructions for filling out this template. You may want to use the 'preview' tab above this textbox to verify formatting before submitting.
-->

## Summary
### Description of the change(s) you made
<!-- Briefly summarize your changes in 1-2 sentences here. -->


### Manual verification steps performed
1. Step 1
2. Step 2
3. ...

### Screenshots (if applicable)
<!-- If not applicable, please delete this section -->

### Does this introduce any tech-debt items?
<!-- List anything that will need to be addressed later -->
___
## Reviewer guidance
### How can a reviewer test these changes?
<!-- If not applicable, please delete this section -->


### Are there any risky areas that deserve extra testing?
<!-- If not applicable, please delete this section -->


## References
<!--
Additional, helpful things to add in this section:
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
 * references to relevant issues or Notion projects
-->

## Comments
<!-- Additional comments may be added here -->

----

### Contributor's Checklist
<!-- After saving the PR, come through to tick off completed checklist items. Delete any sections that are not applicable to your PR -->

PR process:

- [ ] If this is an important user-facing change, PR or related issue the `CHANGELOG` label been added to this PR. Note: items with this label will be added to the [CHANGELOG](https://github.com/learningequality/studio/blob/master/CHANGELOG.md) at a later time
- [ ] If this includes an internal dependency change, a link to the diff is provided
- [ ] The `docs` label has been added if this introduces a change that needs to be updated in the [user docs](https://kolibri-studio.readthedocs.io/en/latest/index.html)?
- [ ] If any Python requirements have changed, the updated `requirements.txt` files also included in this PR
- [ ] Opportunities for using Google Analytics here are noted
- [ ] Migrations are [safe for a large db](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/)

Studio-specifc:

- [ ] All user-facing strings are translated properly
- [ ] The `notranslate` class been added to elements that shouldn't be translated by Google Chrome's automatic translation feature (e.g. icons, user-generated text)
- [ ] All UI components are LTR and RTL compliant
- [ ] Views are organized into `pages`, `components`, and `layouts` directories [as described in the docs](https://github.com/learningequality/studio/blob/vue-refactor/docs/architecture.md#where-does-the-frontend-code-live)
- [ ] Users' storage used is recalculated properly on any changes to main tree files
- [ ] If there new ways this uses user data that needs to be factored into our [Privacy Policy](https://github.com/learningequality/studio/tree/master/contentcuration/contentcuration/templates/policies/text), it has been noted.


Testing:

- [ ] Code is clean and well-commented
- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Any new interactions have been added to the [QA Sheet](https://docs.google.com/spreadsheets/d/1HF4Gy6rb_BLbZoNkZEWZonKFBqPyVEiQq4Ve6XgIYmQ/edit#gid=0)
- [ ] Critical and brittle code paths are covered by unit tests
___

### Reviewer's Checklist
#### This section is for reviewers to fill out.

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
